### PR TITLE
Name parameter required for nearbysearch

### DIFF
--- a/lib/google-locations.js
+++ b/lib/google-locations.js
@@ -31,6 +31,7 @@ GoogleLocations.prototype.search = function(options, cb) {
   options = _.defaults(options, {
     location: [37.42291810, -122.08542120],
     radius: 10,
+    name: 'A',
     language: 'en',
     rankby: 'prominence',
     types: []

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,12 +7,12 @@ fakeweb.allowNetConnect = false;
 
 // fake the search - basic example
 fakeweb.registerUri({
-  uri: 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=37.4229181%2C-122.0854212&radius=10&language=en&rankby=prominence&key=fake_key',
+  uri: 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=37.4229181%2C-122.0854212&radius=10&name=A&language=en&rankby=prominence&key=fake_key',
   body: '{"results" : [{"name": "Google", "place_id":"ABC123"}], "status" : "OK"}'
 });
 // fake the search -- by address example
 fakeweb.registerUri({
-  uri: 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=37.4229181%2C-122.0854212&rankby=distance&radius=&language=en&key=fake_key',
+  uri: 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=37.4229181%2C-122.0854212&rankby=distance&radius=&name=A&language=en&key=fake_key',
   body: '{"results" : [{"name": "Google", "place_id":"ABC123"}], "status" : "OK"}'
 });
 // fake the autocomplete


### PR DESCRIPTION
Default name to 'A' if a name parameter is not passed in. Closes #7.
