### PR TITLE
Pass custom headers into request module

### DIFF
--- a/lib/google-locations.js
+++ b/lib/google-locations.js
@@ -202,12 +202,14 @@ function _generateUrl(context, query, type, method) {
   //https://maps.googleapis.com/maps/api/geocode/json?
   _.compact(query); 
   query.key = context.config.key;
-  return url.parse(url.format({
+  var request_query = url.parse(url.format({
     protocol: 'https',
     hostname: context.config.host,
     pathname: context.config.path + type + '/' + (method ? method + '/' : '') + context.config.format,
     query: query
   }));
+  request_query.headers = context.config.headers;
+  return request_query;
 }
 
 module.exports = GoogleLocations;


### PR DESCRIPTION
Headers were not being added to the config object passed into the request module. The headers needed to be added to request_query. I chose to do that inside _generateUrl, which is the only private method with access to 'this' referencing the SimonAPI object and its config values.

Closes #18.
