### PR TITLE
Added deep copy for each config object

### DIFF
--- a/lib/google-locations.js
+++ b/lib/google-locations.js
@@ -4,6 +4,8 @@ var https = require('https'),
 
 
 var GoogleLocations = function(key, options) {
+  // Copy options object
+  var options = _.extend({}, options);
   // Set default options
   if (!options) options = {};
   options = _.defaults(options, {
@@ -28,6 +30,8 @@ var GoogleLocations = function(key, options) {
 
 //Google place search
 GoogleLocations.prototype.search = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   options = _.defaults(options, {
     location: [37.42291810, -122.08542120],
     radius: 10,
@@ -49,6 +53,8 @@ GoogleLocations.prototype.search = function(options, cb) {
 };
 
 GoogleLocations.prototype.textsearch = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   options = _.defaults(options, {
     query: 'Google near Mountain View, CA'
   });
@@ -57,6 +63,8 @@ GoogleLocations.prototype.textsearch = function(options, cb) {
 };
 
 GoogleLocations.prototype.autocomplete = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   options = _.defaults(options, {
     language: "en",
   });
@@ -65,6 +73,8 @@ GoogleLocations.prototype.autocomplete = function(options, cb) {
 };
 
 GoogleLocations.prototype.details = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   if (!options.placeid) return cb({error: 'placeid string required'});
   options = _.defaults(options, {
     language: 'en'
@@ -74,6 +84,8 @@ GoogleLocations.prototype.details = function(options, cb) {
 };
 
 GoogleLocations.prototype.geocodeAddress = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   if (!options.address) return cb({error: 'Address string required'});
   options = _.defaults(options, {
     language: 'en'
@@ -85,6 +97,8 @@ GoogleLocations.prototype.geocodeAddress = function(options, cb) {
 };
 
 GoogleLocations.prototype.reverseGeocode = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   options = _.defaults(options, {
     latlng: [37.42291810, -122.08542120],
     language: 'en'
@@ -96,6 +110,8 @@ GoogleLocations.prototype.reverseGeocode = function(options, cb) {
 };
 
 GoogleLocations.prototype.searchByAddress = function(config, cb) {
+  // Copy options object
+  var config = _.extend({}, config);
   if (!config.address) return cb({error: "Address string required"});
   var _self = this;
   var options = _generateOptions(config);
@@ -115,6 +131,8 @@ GoogleLocations.prototype.searchByAddress = function(config, cb) {
 };
 
 GoogleLocations.prototype.searchByPhone = function(options, cb) {
+  // Copy options object
+  var options = _.extend({}, options);
   if (!options.phone) return cb({error: "Missing required parameter 'phone'"});
   options.maxResults = options.maxResults || 1;
   var _self = this;
@@ -150,6 +168,8 @@ function _batchDetails(context, result, maxResults, cb) {
 }
 
 function _generateOptions(geocodeOptions) {
+  // Copy options object
+  var geocodeOptions = _.extend({}, geocodeOptions);
   var options = {geocode: geocodeOptions, search: {maxResults: 1, rankby: "distance"}};
   var keys = ['name', 'maxResults', 'rankby', 'radius'];
   for (var i = 0; i < keys.length; i++) {
@@ -167,6 +187,8 @@ function _generateOptions(geocodeOptions) {
 }
 
 function _searchQuery(location, searchOptions) {
+  // Copy options object
+  var searchOptions = _.extend({}, searchOptions);
   var query = {location: [location.lat, location.lng], rankby: searchOptions.rankby};
   if (searchOptions.name) query.name = searchOptions.name;
   if (searchOptions.radius) query.radius = searchOptions.radius;


### PR DESCRIPTION
Why this changes are needed:

I was reusing object that was passed to locations.geocodeAddress method, and I noticed it was poluted by the method (objects are passed by refference). Overall its good practice to keep functions "pure".

Old tests are passing, I didnt write new tests because I'm not familiar with wovs test framework.